### PR TITLE
增加对FreeBSD的支持

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,13 @@ include co.mk
 CFLAGS += -g -fno-strict-aliasing -O2 -Wall -export-dynamic \
 	-Wall -pipe  -D_GNU_SOURCE -D_REENTRANT -fPIC -Wno-deprecated -m64
 
+UNAME := $(shell uname -s)
+
+ifeq ($(UNAME), FreeBSD)
 LINKS += -g -L./lib -lcolib -lpthread
+else
+LINKS += -g -L./lib -lcolib -lpthread -ldl
+endif
 
 COLIB_OBJS=co_epoll.o co_routine.o co_hook_sys_call.o coctx_swap.o coctx.o
 #co_swapcontext.o

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ include co.mk
 CFLAGS += -g -fno-strict-aliasing -O2 -Wall -export-dynamic \
 	-Wall -pipe  -D_GNU_SOURCE -D_REENTRANT -fPIC -Wno-deprecated -m64
 
-LINKS += -g -L./lib -lcolib -lpthread -ldl 
+LINKS += -g -L./lib -lcolib -lpthread
 
 COLIB_OBJS=co_epoll.o co_routine.o co_hook_sys_call.o coctx_swap.o coctx.o
 #co_swapcontext.o

--- a/co.mk
+++ b/co.mk
@@ -23,8 +23,7 @@ MAIL_ROOT=.
 SRCROOT=.
 
 ##define the compliers
-CPP = g++
-CC  = gcc
+CPP = $(CXX)
 AR = ar -rc
 RANLIB = ranlib
 

--- a/co_epoll.cpp
+++ b/co_epoll.cpp
@@ -22,7 +22,7 @@
 #include <errno.h>
 #include <string.h>
 
-#ifndef __APPLE__
+#if !defined( __APPLE__ ) && !defined( __FreeBSD__ )
 
 int	co_epoll_wait( int epfd,struct co_epoll_res *events,int maxevents,int timeout )
 {

--- a/co_epoll.h
+++ b/co_epoll.h
@@ -26,7 +26,7 @@
 #include <time.h>
 #include <time.h>
 
-#ifndef __APPLE__
+#if !defined( __APPLE__ ) && !defined( __FreeBSD__ )
 
 #include <sys/epoll.h>
 

--- a/co_hook_sys_call.cpp
+++ b/co_hook_sys_call.cpp
@@ -865,7 +865,7 @@ struct hostent *gethostbyname(const char *name)
 {
 	HOOK_SYS_FUNC( gethostbyname );
 
-#ifdef __APPLE__
+#if defined( __APPLE__ ) || defined( __FreeBSD__ )
 	return g_sys_gethostbyname_func( name );
 #else
 	if (!co_is_enable_sys_hook())
@@ -913,7 +913,7 @@ struct hostbuf_wrap
 
 CO_ROUTINE_SPECIFIC(hostbuf_wrap, __co_hostbuf_wrap);
 
-#ifndef __APPLE__
+#if !defined( __APPLE__ ) && !defined( __FreeBSD__ )
 struct hostent *co_gethostbyname(const char *name)
 {
 	if (!name)

--- a/co_routine.cpp
+++ b/co_routine.cpp
@@ -126,6 +126,12 @@ static pid_t GetPid()
 		{
 			tid = pid;
 		}
+#elif defined( __FreeBSD__ )
+		syscall(SYS_thr_self, &tid);
+		if( tid < 0 )
+		{
+			tid = pid;
+		}
 #else 
         tid = syscall( __NR_gettid );
 #endif

--- a/coctx_swap.S
+++ b/coctx_swap.S
@@ -17,7 +17,7 @@
 */
 
 .globl coctx_swap
-#if !defined( __APPLE__ )
+#if !defined( __APPLE__ ) && !defined( __FreeBSD__ )
 .type  coctx_swap, @function
 #endif
 coctx_swap:

--- a/example_echosvr.cpp
+++ b/example_echosvr.cpp
@@ -34,6 +34,12 @@
 #include <unistd.h>
 #include <errno.h>
 
+#ifdef __FreeBSD__
+#include <cstring>
+#include <sys/types.h>
+#include <sys/wait.h>
+#endif
+
 using namespace std;
 struct task_t
 {

--- a/example_poll.cpp
+++ b/example_poll.cpp
@@ -33,6 +33,11 @@
 #include <vector>
 #include <set>
 #include <unistd.h>
+
+#ifdef __FreeBSD__
+#include <cstring>
+#endif
+
 using namespace std;
 
 struct task_t


### PR DESCRIPTION
1.FreeBSD也是基于kqueue的，大部分可以复用mac上的兼容代码。
2.在Makefile里面增加了对OS的检测，FreeBSD的libc原生支持共享库的操作，无需-ldl。
3.CC和CXX一般是环境变量，分别指向cc和c++，无需在co.mk中设置（CPP变量名使用有点误导人，一般CPP是cpp工具，是C的Preprocessing，CPP这里暂时没动）。
