### PR TITLE
Fixes deprecated syscall issue on macOS 10.12

### DIFF
--- a/co_routine.cpp
+++ b/co_routine.cpp
@@ -122,7 +122,12 @@ static pid_t GetPid()
     {
         pid = getpid();
 #if defined( __APPLE__ )
-		tid = syscall( SYS_gettid );
+  #include <Availability.h>
+  #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_12
+    tid = pthread_mach_thread_np(pthread_self());
+  #else
+    tid = syscall( SYS_gettid );
+  #endif
 		if( -1 == (long)tid )
 		{
 			tid = pid;


### PR DESCRIPTION
syscall() has been deprecated and is not available on macOS 10.12.

There are two ways to get unique thread ID after 10.12:

`pthread_threadid_np(NULL, &tid64)`
`pthread_mach_thread_np(pthread_self())`

The first one gets an ID which might be larger than 204800 in g_arrCoEnvPerThread.
And the second one is safer cause mach_port_t is quit small actually.