### PR TITLE
replace static array g_arrCoEnvPerThread with thread local var

### DIFF
--- a/co_routine.cpp
+++ b/co_routine.cpp
@@ -701,12 +701,12 @@ static short EpollEvent2Poll( uint32_t events )
 	return e;
 }
 
-static stCoRoutineEnv_t* g_arrCoEnvPerThread[ 204800 ] = { 0 };
+static __thread stCoRoutineEnv_t* gCoEnvPerThread = NULL;
+
 void co_init_curr_thread_env()
 {
-	pid_t pid = GetPid();	
-	g_arrCoEnvPerThread[ pid ] = (stCoRoutineEnv_t*)calloc( 1,sizeof(stCoRoutineEnv_t) );
-	stCoRoutineEnv_t *env = g_arrCoEnvPerThread[ pid ];
+	gCoEnvPerThread = (stCoRoutineEnv_t*)calloc( 1, sizeof(stCoRoutineEnv_t) );
+	stCoRoutineEnv_t *env = gCoEnvPerThread;
 
 	env->iCallStackSize = 0;
 	struct stCoRoutine_t *self = co_create_env( env, NULL, NULL,NULL );
@@ -724,7 +724,7 @@ void co_init_curr_thread_env()
 }
 stCoRoutineEnv_t *co_get_curr_thread_env()
 {
-	return g_arrCoEnvPerThread[ GetPid() ];
+	return gCoEnvPerThread;
 }
 
 void OnPollProcessEvent( stTimeoutItem_t * ap )


### PR DESCRIPTION
There is no reason to use a global static array to implement thread local storage.