### PR TITLE
fix : modify optimization level to -O0 when in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,11 @@ set(CMAKE_MACOSX_RPATH 0)
 set(LIBCO_VERSION   0.5)
 
 # Set cflags
-set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -g -fno-strict-aliasing -O2 -Wall -export-dynamic -Wall -pipe  -D_GNU_SOURCE -D_REENTRANT -fPIC -Wno-deprecated -m64)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -g -fno-strict-aliasing -O0 -Wall -export-dynamic -Wall -pipe  -D_GNU_SOURCE -D_REENTRANT -fPIC -Wno-deprecated -m64)
+else()
+    set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -g -fno-strict-aliasing -O2 -Wall -export-dynamic -Wall -pipe  -D_GNU_SOURCE -D_REENTRANT -fPIC -Wno-deprecated -m64)
+endif()
 
 # Use c and asm
 enable_language(C ASM)

--- a/example_thread.cpp
+++ b/example_thread.cpp
@@ -39,6 +39,10 @@ static void *routine_func( void * )
 }
 int main(int argc,char *argv[])
 {
+	if (arac != 2) {
+	    printf("Usage:./example_thread x");
+	    return -1;
+	}
 	int cnt = atoi( argv[1] );
 
 	pthread_t tid[ cnt ];


### PR DESCRIPTION
Optimization level of g++ whill affect debug options of gdb.
I meet error when i use gdb to debug libco in ubuntu that gdb list can't refer to source file correctly,
so it should be -O0 in debug mode.