### PR TITLE
Fix 20 dependency issues with auto dependency generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,4 +81,19 @@ libco-$(version).src.tar.gz:
 clean:
 	$(CLEAN) *.o $(PROGS)
 	rm -fr MANIFEST lib solib libco-$(version).src.tar.gz libco-$(version)
+	rm -f $(AUTODEPS)	
+
+# create a list of auto dependencies
+AUTODEPS:= $(patsubst %.o,%.d, $(COLIB_OBJS))
+
+ # include by auto dependencies
+-include $(AUTODEPS)
+
+%.o: %.cpp %.d
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.d: %.cpp
+	$(CC) $(CFLAGS) -MM -MT"$@ $(@:.d=.o)" -MP -MF $@ $<
+
+$(PROGS): libcolib.a libcolib.so
 

--- a/co.mk
+++ b/co.mk
@@ -63,7 +63,7 @@ OBJS = $(CPPOBJS) $(COBJS)
 CPPCOMPI=$(CPP) $(CFLAGS) -Wno-deprecated
 CCCOMPI=$(CC) $(CFLAGS)
 
-BUILDEXE = $(CPP) $(BFLAGS) -o $@ $^ $(LINKS) 
+BUILDEXE = $(CPP) $(BFLAGS) -o $@ $< $(LINKS) 
 CLEAN = rm -f *.o 
 
 CPPCOMPILE = $(CPPCOMPI) $< $(FLAGS) $(INCLS) $(MTOOL_INCL) -o $@


### PR DESCRIPTION
Hi,

We have found and fixed 80 dependency issues in the Makefile.
Those issues can cause incorrect results when the project is incrementally built.
For example, any changes in a header file will not cause the object file to be rebuilt, which is incorrect.
I've tested it on my computer, the fixed version worked as expected.
I fix the header dependencies by using the Auto-Dependency Generation technique mentioned here: http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/

Abd for the lib dependencies, I manually add a rule in the Makefile. 

Looking forward to your confirmation.


Thanks
Vemake