### PR TITLE
fix F_GETFD can't get O_NONBLOCK flag, F_GETFL can

### DIFF
--- a/co_hook_sys_call.cpp
+++ b/co_hook_sys_call.cpp
@@ -672,9 +672,6 @@ int fcntl(int fildes, int cmd, ...)
 		case F_GETFD:
 		{
 			ret = g_sys_fcntl_func( fildes,cmd );
-      if (lp && !(lp->user_flag & O_NONBLOCK)) {
-          ret = ret & (~O_NONBLOCK);
-      }
 			break;
 		}
 		case F_SETFD:
@@ -686,6 +683,9 @@ int fcntl(int fildes, int cmd, ...)
 		case F_GETFL:
 		{
 			ret = g_sys_fcntl_func( fildes,cmd );
+			if (lp && !(lp->user_flag & O_NONBLOCK)) {
+				ret = ret & (~O_NONBLOCK);
+			}
 			break;
 		}
 		case F_SETFL:


### PR DESCRIPTION
F_GETFD can't get O_NONBLOCK flag, test code:

```c
#include <stdio.h>
#include <sys/socket.h>
#include <sys/types.h>
#include <netinet/in.h>
#include <string.h>
#include <unistd.h>
#include <fcntl.h>
#include <errno.h>

int main(int argc, char* argv[])
{
	int fd = open("/home/1.txt", O_RDWR|O_NONBLOCK|O_CREAT);
	if (fd  == -1) {
		printf("failed open /home/1.txt\n");
		return -1;
	}

	int val1 = fcntl(fd, F_GETFL, 0);
	if (val1 < 0) {
		printf("failed fcntl F_GETFL\n");
		return -2;
	}

	printf("val1 %x\n", val1);
        if (val1 & O_NONBLOCK) {
             printf("val1 F_GETFL O_NONBLOCK is set\n");
        }

	int val2 = fcntl(fd, F_GETFD, 0);
	if (val2 < 0) {
		printf("failed fcntl F_GETFL\n");
		return -2;
	}

	printf("val2 %x\n", val2);
        if (val2 & O_NONBLOCK) {
            printf("val2  F_GETFD O_NONBLOCK is set\n");
        }

	close(fd);

	return 0;
}
```

result:
val1 8802
val1 F_GETFL O_NONBLOCK is set
val2 0
