### PR TITLE
fix example_setenv.cpp sprintf  crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ README.md
 *.exe
 *.out
 *.app
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ set(SOURCE_FILES
         co_hook_sys_call.cpp
         co_routine.cpp
         coctx.cpp
-        coctx_swap.S)
+        coctx_swap.S
+        co_comm.cpp
+        )
 
 # Add static and shared library target
 add_library(colib_static STATIC ${SOURCE_FILES})

--- a/example_setenv.cpp
+++ b/example_setenv.cpp
@@ -23,6 +23,8 @@
 #include <stdlib.h>
 #include <queue>
 #include "co_routine.h"
+#include <sstream> 
+
 
 const char* CGI_ENV_HOOK_LIST [] = 
 {
@@ -39,16 +41,17 @@ void SetAndGetEnv(int iRoutineID)
 	//use poll as sleep
 	poll(NULL, 0, 500);
 
-	char sBuf[128];
-	sprintf(sBuf, "cgi_routine_%d", iRoutineID);
-	int ret = setenv("CGINAME", sBuf, 1);
+	 std::ostringstream ostr;
+    ostr << "iRoutineID: " << iRoutineID;
+    const char *pstr =  ostr.str().c_str();
+    int ret = setenv("CGINAME", pstr, 1);
 	if (ret)
 	{
 		printf("%s:%d set env err ret %d errno %d %s\n", __func__, __LINE__,
 				ret, errno, strerror(errno));
 		return;
 	}
-	printf("routineid %d set env CGINAME %s\n", iRoutineID, sBuf);
+	printf("routineid %d set env CGINAME %s\n", iRoutineID, pstr);
 
 	poll(NULL, 0, 500);
 


### PR DESCRIPTION
fixed example_setenv crash bug,  because of  sprintf  is not thread safe