### PR TITLE
fix: free main coroutine's unsed stack memory

### DIFF
--- a/co_routine.cpp
+++ b/co_routine.cpp
@@ -747,6 +747,7 @@ void co_init_curr_thread_env()
 	env->iCallStackSize = 0;
 	struct stCoRoutine_t *self = co_create_env( env, NULL, NULL,NULL );
 	self->cIsMain = 1;
+	free(self->stack_mem->stack_buffer);
 
 	env->pending_co = NULL;
 	env->occupy_co = NULL;


### PR DESCRIPTION
在初始化线程环境的时候，同样是利用co_create_env创建主协程，里面在堆上面为主协程分配了一块栈空间，但是主协程使用了系统栈，这个128kb空间一直没有使用，被浪费了。（聊胜于无）