### PR TITLE
Fix cmake to compile comm.cpp. Add support of CMake install.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ enable_language(C ASM)
 
 # Add source files
 set(SOURCE_FILES
+        co_comm.cpp
         co_epoll.cpp
         co_hook_sys_call.cpp
         co_routine.cpp
@@ -53,3 +54,17 @@ add_example_target(poll)
 add_example_target(setenv)
 add_example_target(specific)
 add_example_target(thread)
+
+
+install(TARGETS 
+        colib_static 
+        colib_shared 
+        DESTINATION lib)
+install(FILES 
+        co_closure.h
+        co_comm.h
+        co_epoll.h 
+        co_routine_inner.h
+        co_routine_specific.h
+        co_routine.h
+        DESTINATION include/libco)


### PR DESCRIPTION
1. Fix cmake to compile comm.cpp. 
2. Add support of CMake install. Headers are installed to `include/libco`