### PR TITLE
fix: 修复pfn没有析构导致的内存泄漏问题。

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,55 +1,20 @@
-cmake_minimum_required(VERSION 2.8)
-project(libco)
+cmake_minimum_required(VERSION 2.8.12)
 
-# This for mac osx only
-set(CMAKE_MACOSX_RPATH 0)
+message(STATUS "CURRENT_DIR: ${CMAKE_CURRENT_LIST_DIR}")
 
-# Set lib version
-set(LIBCO_VERSION   0.5)
+#set (CMAKE_CXX_FLAGS "-std=c++11 -pthread")
+#set (CMAKE_CXX_STANDARD 11)
 
-# Set cflags
-set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -g -fno-strict-aliasing -O2 -Wall -export-dynamic -Wall -pipe  -D_GNU_SOURCE -D_REENTRANT -fPIC -Wno-deprecated -m64)
+enable_language(C CXX ASM)
 
-# Use c and asm
-enable_language(C ASM)
+message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+message(STATUS "CMAKE_CXX_STANDARD: ${CMAKE_CXX_STANDARD}")
 
-# Add source files
-set(SOURCE_FILES
-        co_epoll.cpp
-        co_hook_sys_call.cpp
-        co_routine.cpp
-        coctx.cpp
-        coctx_swap.S)
+# 查找当前目录下的所有源文件
+# 并将名称保存到 DIR_LIB_SRCS 变量
+aux_source_directory(. DIR_LIB_SRCS)
+set(DIR_LIB_SRCS ${DIR_LIB_SRCS} coctx_swap.S)
+# 生成
+#add_executable(DSAdmin ${DIR_LIB_SRCS})
+add_library (libco STATIC ${DIR_LIB_SRCS})
 
-# Add static and shared library target
-add_library(colib_static STATIC ${SOURCE_FILES})
-add_library(colib_shared SHARED ${SOURCE_FILES})
-
-# Set library output name
-set_target_properties(colib_static PROPERTIES OUTPUT_NAME colib)
-set_target_properties(colib_shared PROPERTIES OUTPUT_NAME colib)
-
-set_target_properties(colib_static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-set_target_properties(colib_shared PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-
-# Set shared library version, will generate libcolib.${LIBCO_VERSION}.so and a symbol link named libcolib.so
-# For mac osx, the extension name will be .dylib
-set_target_properties(colib_shared PROPERTIES VERSION ${LIBCO_VERSION} SOVERSION ${LIBCO_VERSION})
-
-
-
-# Macro for add example target
-macro(add_example_target EXAMPLE_TARGET)
-    add_executable("example_${EXAMPLE_TARGET}" "example_${EXAMPLE_TARGET}.cpp")
-    target_link_libraries("example_${EXAMPLE_TARGET}" colib_static pthread dl)
-endmacro(add_example_target)
-
-add_example_target(closure)
-add_example_target(cond)
-add_example_target(copystack)
-add_example_target(echocli)
-add_example_target(echosvr)
-add_example_target(poll)
-add_example_target(setenv)
-add_example_target(specific)
-add_example_target(thread)

--- a/co_bt.py
+++ b/co_bt.py
@@ -1,0 +1,48 @@
+import gdb
+
+class CoroutinesCallStack(gdb.Command):
+    def __init__(self):
+        super(CoroutinesCallStack, self).__init__("co_bt", gdb.COMMAND_STACK)
+
+    def invoke(self, arg, from_tty):
+        coctx_array_type = gdb.lookup_type("void").pointer().pointer()
+        coctx_array = gdb.parse_and_eval("coctx_array").cast(coctx_array_type)
+
+        coctx_array_length = int(gdb.parse_and_eval("coctx_array_length"))
+        print("Coroutine count: %d" % coctx_array_length)
+
+        print("print callstacks...\n")
+        max_depth = 24
+        for idx in range(coctx_array_length):
+            coctx_ptr = coctx_array[idx].cast(gdb.lookup_type("void").pointer())
+            coctx_addr = int(coctx_ptr.dereference())
+
+            rbp = int(gdb.Value(coctx_addr + 48).cast(gdb.lookup_type("long").pointer()))
+            rsp = int(gdb.Value(coctx_addr + 104).cast(gdb.lookup_type("long").pointer()))
+            rip = int(gdb.Value(coctx_addr + 72).cast(gdb.lookup_type("long").pointer()))
+            rbx = int(gdb.Value(coctx_addr + 96).cast(gdb.lookup_type("long").pointer()))
+
+            print("Coroutine %d (context address: 0x%x):" % (idx, coctx_addr))
+            for i in range(max_depth):
+                # 读取当前栈帧的调用地址和栈帧指针
+                call_addr = int(gdb.Value(rbp + 8).cast(gdb.lookup_type("long").pointer()))
+                frame_ptr = int(gdb.Value(rbp).cast(gdb.lookup_type("long").pointer()))
+
+                # 如果调用地址为0，说明已经到达调用栈底部
+                if call_addr == 0:
+                    break
+
+                # 打印当前栈帧的信息
+                print("  frame %d: 0x%x" % (i, call_addr))
+
+                # 更新栈帧指针和调用地址，继续遍历调用栈
+                rbp = frame_ptr
+                rip = call_addr
+
+                # 如果遍历到了最大深度，结束遍历
+                if i == max_depth - 1:
+                    print("  ...")
+                    break
+            print("\n")
+
+CoroutinesCallStack()

--- a/co_epoll.cpp
+++ b/co_epoll.cpp
@@ -23,7 +23,7 @@
 #include <string.h>
 
 #if !defined( __APPLE__ ) && !defined( __FreeBSD__ )
-
+#include <unistd.h>
 int	co_epoll_wait( int epfd,struct co_epoll_res *events,int maxevents,int timeout )
 {
 	return epoll_wait( epfd,events->events,maxevents,timeout );
@@ -36,7 +36,10 @@ int	co_epoll_create( int size )
 {
 	return epoll_create( size );
 }
-
+int co_epoll_close( int fd )
+{
+    return close(fd);
+}
 struct co_epoll_res *co_epoll_res_alloc( int n )
 {
 	struct co_epoll_res * ptr = 

--- a/co_epoll.h
+++ b/co_epoll.h
@@ -39,6 +39,7 @@ struct co_epoll_res
 int 	co_epoll_wait( int epfd,struct co_epoll_res *events,int maxevents,int timeout );
 int 	co_epoll_ctl( int epfd,int op,int fd,struct epoll_event * );
 int 	co_epoll_create( int size );
+int 	co_epoll_close( int fd );
 struct 	co_epoll_res *co_epoll_res_alloc( int n );
 void 	co_epoll_res_free( struct co_epoll_res * );
 

--- a/co_routine.cpp
+++ b/co_routine.cpp
@@ -545,7 +545,7 @@ void co_free( stCoRoutine_t *co )
         if(co->stack_mem->occupy_co == co)
             co->stack_mem->occupy_co = NULL;
     }
-	co->pfn = NULL; //joezzhu fix the memory leak bug at 2022-03-09
+    co->pfn = NULL; //joezzhu fix the memory leak bug at 2022-03-09
     free( co );
 }
 void co_release( stCoRoutine_t *co )

--- a/co_routine.cpp
+++ b/co_routine.cpp
@@ -545,7 +545,7 @@ void co_free( stCoRoutine_t *co )
         if(co->stack_mem->occupy_co == co)
             co->stack_mem->occupy_co = NULL;
     }
-
+	co->pfn = NULL; //joezzhu fix the memory leak bug at 2022-03-09
     free( co );
 }
 void co_release( stCoRoutine_t *co )

--- a/co_routine.h
+++ b/co_routine.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <sys/poll.h>
 #include <pthread.h>
+#include <functional>
 
 //1.struct
 
@@ -41,11 +42,12 @@ struct stCoRoutineAttr_t
 
 struct stCoEpoll_t;
 typedef int (*pfn_co_eventloop_t)(void *);
-typedef void *(*pfn_co_routine_t)( void * );
+//typedef void *(*pfn_co_routine_t)( void * );
+typedef std::function<void* (void*)> pfn_co_routine_t;
 
 //2.co_routine
 
-int 	co_create( stCoRoutine_t **co,const stCoRoutineAttr_t *attr,void *(*routine)(void*),void *arg );
+int 	co_create( stCoRoutine_t **co,const stCoRoutineAttr_t *attr, pfn_co_routine_t pfn,void *arg );
 void    co_resume( stCoRoutine_t *co );
 void    co_yield( stCoRoutine_t *co );
 void    co_yield_ct(); //ct = current thread
@@ -59,6 +61,8 @@ void 	co_eventloop( stCoEpoll_t *ctx,pfn_co_eventloop_t pfn,void *arg );
 
 //3.specific
 
+int     co_create_specific( pthread_key_t* key );
+int     co_delete_specific( pthread_key_t key );
 int 	co_setspecific( pthread_key_t key, const void *value );
 void *	co_getspecific( pthread_key_t key );
 

--- a/co_routine_inner.h
+++ b/co_routine_inner.h
@@ -58,6 +58,7 @@ struct stCoRoutine_t
 	char cIsMain;
 	char cEnableSysHook;
 	char cIsShareStack;
+    char cCondTimeout;
 
 	void *pvEnv;
 
@@ -103,6 +104,7 @@ void 		FreeEpoll( stCoEpoll_t *ctx );
 
 stCoRoutine_t *		GetCurrThreadCo();
 void 				SetEpoll( stCoRoutineEnv_t *env,stCoEpoll_t *ev );
+void 				RecreateEpollFd( stCoRoutineEnv_t *env );
 
 typedef void (*pfnCoRoutineFunc_t)();
 

--- a/print_co.py
+++ b/print_co.py
@@ -1,0 +1,63 @@
+import gdb
+
+class PrintCoroutines(gdb.Command):
+    def __init__(self):
+        super(PrintCoroutines, self).__init__("print_coroutines", gdb.COMMAND_STACK)
+
+    def invoke(self, arg, from_tty):
+        coctx_array_type = gdb.lookup_type("void").pointer().pointer()
+        coctx_array = gdb.parse_and_eval("coctx_array").cast(coctx_array_type)
+
+        coctx_array_length = int(gdb.parse_and_eval("coctx_array_length"))
+        print("Coroutine count: %d" % coctx_array_length)
+
+        print("backup registers...\n")
+        original_registers1 = {}
+        try:
+            for reg in ['rbp', 'rsp', 'rip', 'rbx']:
+                original_registers1[reg] = int(gdb.parse_and_eval("${}".format(reg)))
+        except gdb.error:
+            print("get original_registers1 error\n")
+            original_registers1 = {}
+
+        original_registers2 = {}
+        try:
+            for reg in ['rcx', 'rdx', 'rsi', 'rdi', 'r8', 'r9', 'r12', 'r13', 'r14', 'r15']:
+                original_registers2[reg] = int(gdb.parse_and_eval("${}".format(reg)))
+        except gdb.error:
+            print("get original_registers2 error\n")
+            original_registers2 = {}
+
+        print("print callstacks...\n")
+        gdb.execute("set backtrace limit 24")
+        for idx in range(coctx_array_length):
+            coctx_ptr = coctx_array[idx].cast(gdb.lookup_type("void").pointer())
+            coctx_addr = int(coctx_ptr.dereference())
+
+            gdb.execute("set $rbp = *(%d + 48)" % coctx_addr)
+            gdb.execute("set $rsp = *(%d + 104)" % coctx_addr)
+            gdb.execute("set $rip = *(%d + 72)" % coctx_addr)
+            gdb.execute("set $rbx = *(%d + 96)" % coctx_addr)
+
+            gdb.execute("set $rcx = *(%d + 88)" % coctx_addr)
+            gdb.execute("set $rdx = *(%d + 80)" % coctx_addr)
+            gdb.execute("set $rsi = *(%d + 64)" % coctx_addr)
+            gdb.execute("set $rdi = *(%d + 56)" % coctx_addr)
+            gdb.execute("set $r8 = *(%d + 40)" % coctx_addr)
+            gdb.execute("set $r9 = *(%d + 32)" % coctx_addr)
+            gdb.execute("set $r12 = *(%d + 24)" % coctx_addr)
+            gdb.execute("set $r13 = *(%d + 16)" % coctx_addr)
+            gdb.execute("set $r14 = *(%d + 8)" % coctx_addr)
+            gdb.execute("set $r15 = *(%d)" % coctx_addr)
+
+            print("Coroutine %d (context address: 0x%x):" % (idx, coctx_addr))
+            gdb.execute("bt")
+            print("\n")
+
+        print("restore registers...\n")
+        for reg, value in original_registers1.items():
+            gdb.execute("set ${} = {}".format(reg, value))
+        for reg, value in original_registers2.items():
+            gdb.execute("set ${} = {}".format(reg, value))
+
+PrintCoroutines()


### PR DESCRIPTION
std::function<void* (void*)> 捕获的参数可能需要析构。我在捕获的参数里包括了智能指针，没能正确释放，由此发现了此问题。