### PR TITLE
允许 co_create 使用任意多参数的入口函数。

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ enable_language(C ASM)
 
 # Add source files
 set(SOURCE_FILES
+        co_comm.cpp
         co_epoll.cpp
         co_hook_sys_call.cpp
         co_routine.cpp

--- a/co_routine.cpp
+++ b/co_routine.cpp
@@ -265,16 +265,6 @@ void inline Join( TLink*apLink,TLink *apOther )
 	apOther->head = apOther->tail = NULL;
 }
 
-/////////////////for copy stack //////////////////////////
-stStackMem_t* co_alloc_stackmem(unsigned int stack_size)
-{
-	stStackMem_t* stack_mem = (stStackMem_t*)malloc(sizeof(stStackMem_t));
-	stack_mem->occupy_co= NULL;
-	stack_mem->stack_size = stack_size;
-	stack_mem->stack_buffer = (char*)malloc(stack_size);
-	stack_mem->stack_bp = stack_mem->stack_buffer + stack_size;
-	return stack_mem;
-}
 
 stShareStack_t* co_alloc_sharestack(int count, int stack_size)
 {
@@ -293,17 +283,6 @@ stShareStack_t* co_alloc_sharestack(int count, int stack_size)
 	return share_stack;
 }
 
-static stStackMem_t* co_get_stackmem(stShareStack_t* share_stack)
-{
-	if (!share_stack)
-	{
-		return NULL;
-	}
-	int idx = share_stack->alloc_idx % share_stack->count;
-	share_stack->alloc_idx++;
-
-	return share_stack->stack_array[idx];
-}
 
 
 // ----------------------------------------------------------------------------
@@ -454,68 +433,6 @@ static int CoRoutineFunc( stCoRoutine_t *co,void * )
 	co_yield_env( env );
 
 	return 0;
-}
-
-
-
-struct stCoRoutine_t *co_create_env( stCoRoutineEnv_t * env, const stCoRoutineAttr_t* attr,
-		pfn_co_routine_t pfn,void *arg )
-{
-
-	stCoRoutineAttr_t at;
-	if( attr )
-	{
-		memcpy( &at,attr,sizeof(at) );
-	}
-	if( at.stack_size <= 0 )
-	{
-		at.stack_size = 128 * 1024;
-	}
-	else if( at.stack_size > 1024 * 1024 * 8 )
-	{
-		at.stack_size = 1024 * 1024 * 8;
-	}
-
-	if( at.stack_size & 0xFFF ) 
-	{
-		at.stack_size &= ~0xFFF;
-		at.stack_size += 0x1000;
-	}
-
-	stCoRoutine_t *lp = (stCoRoutine_t*)malloc( sizeof(stCoRoutine_t) );
-	
-	memset( lp,0,(long)(sizeof(stCoRoutine_t))); 
-
-
-	lp->env = env;
-	lp->pfn = pfn;
-	lp->arg = arg;
-
-	stStackMem_t* stack_mem = NULL;
-	if( at.share_stack )
-	{
-		stack_mem = co_get_stackmem( at.share_stack);
-		at.stack_size = at.share_stack->stack_size;
-	}
-	else
-	{
-		stack_mem = co_alloc_stackmem(at.stack_size);
-	}
-	lp->stack_mem = stack_mem;
-
-	lp->ctx.ss_sp = stack_mem->stack_buffer;
-	lp->ctx.ss_size = at.stack_size;
-
-	lp->cStart = 0;
-	lp->cEnd = 0;
-	lp->cIsMain = 0;
-	lp->cEnableSysHook = 0;
-	lp->cIsShareStack = at.share_stack != NULL;
-
-	lp->save_size = 0;
-	lp->save_buffer = NULL;
-
-	return lp;
 }
 
 int co_create( stCoRoutine_t **ppco,const stCoRoutineAttr_t *attr,pfn_co_routine_t pfn,void *arg )

--- a/co_routine.h
+++ b/co_routine.h
@@ -22,7 +22,9 @@
 #include <stdint.h>
 #include <sys/poll.h>
 #include <pthread.h>
-
+#include <string.h>
+#include <tuple>
+#include <memory>
 //1.struct
 
 struct stCoRoutine_t;
@@ -43,9 +45,127 @@ struct stCoEpoll_t;
 typedef int (*pfn_co_eventloop_t)(void *);
 typedef void *(*pfn_co_routine_t)( void * );
 
+#include "co_routine_inner.h"
+
 //2.co_routine
 
+static inline stStackMem_t* co_get_stackmem(stShareStack_t* share_stack)
+{
+	if (!share_stack)
+	{
+		return NULL;
+	}
+	int idx = share_stack->alloc_idx % share_stack->count;
+	share_stack->alloc_idx++;
+
+	return share_stack->stack_array[idx];
+}
+
+/////////////////for copy stack //////////////////////////
+inline stStackMem_t* co_alloc_stackmem(unsigned int stack_size)
+{
+	stStackMem_t* stack_mem = (stStackMem_t*)malloc(sizeof(stStackMem_t));
+	stack_mem->occupy_co= NULL;
+	stack_mem->stack_size = stack_size;
+	stack_mem->stack_buffer = (char*)malloc(stack_size);
+	stack_mem->stack_bp = stack_mem->stack_buffer + stack_size;
+	return stack_mem;
+}
+
+inline struct stCoRoutine_t *co_create_env( stCoRoutineEnv_t * env, const stCoRoutineAttr_t* attr,
+		pfn_co_routine_t pfn,void *arg )
+{
+
+	stCoRoutineAttr_t at;
+	if( attr )
+	{
+		memcpy( &at,attr,sizeof(at) );
+	}
+	if( at.stack_size <= 0 )
+	{
+		at.stack_size = 128 * 1024;
+	}
+	else if( at.stack_size > 1024 * 1024 * 8 )
+	{
+		at.stack_size = 1024 * 1024 * 8;
+	}
+
+	if( at.stack_size & 0xFFF )
+	{
+		at.stack_size &= ~0xFFF;
+		at.stack_size += 0x1000;
+	}
+
+	stCoRoutine_t *lp = (stCoRoutine_t*)malloc( sizeof(stCoRoutine_t) );
+
+	memset( lp,0,(long)(sizeof(stCoRoutine_t)));
+
+
+	lp->env = env;
+	lp->pfn = pfn;
+	lp->arg = arg;
+
+	stStackMem_t* stack_mem = NULL;
+	if( at.share_stack )
+	{
+		stack_mem = co_get_stackmem( at.share_stack);
+		at.stack_size = at.share_stack->stack_size;
+	}
+	else
+	{
+		stack_mem = co_alloc_stackmem(at.stack_size);
+	}
+	lp->stack_mem = stack_mem;
+
+	lp->ctx.ss_sp = stack_mem->stack_buffer;
+	lp->ctx.ss_size = at.stack_size;
+
+	lp->cStart = 0;
+	lp->cEnd = 0;
+	lp->cIsMain = 0;
+	lp->cEnableSysHook = 0;
+	lp->cIsShareStack = at.share_stack != NULL;
+
+	lp->save_size = 0;
+	lp->save_buffer = NULL;
+
+	return lp;
+}
+
 int 	co_create( stCoRoutine_t **co,const stCoRoutineAttr_t *attr,void *(*routine)(void*),void *arg );
+
+
+// microcai 添加
+template <typename... Args>
+int 	co_create( stCoRoutine_t **ppco,const stCoRoutineAttr_t *attr,void *(*pfn)(Args...), Args... args)
+{
+
+	if( !co_get_curr_thread_env() )
+	{
+		co_init_curr_thread_env();
+	}
+
+	struct new_func_arg_pack {
+		decltype(pfn) real_func_ptr;
+		std::tuple<Args...> args;
+	};
+
+	auto new_arg = new new_func_arg_pack { pfn, std::tuple<Args...>{std::forward<Args>(args)...} };
+
+	auto wrapper_func = [](void* arg_pack)
+	{
+		auto converted_arg_pack =(new_func_arg_pack*)(arg_pack);
+
+		std::unique_ptr<new_func_arg_pack> auto_delete(converted_arg_pack);
+
+		return std::apply(converted_arg_pack->real_func_ptr, std::move(converted_arg_pack->args));
+	};
+
+	stCoRoutine_t *co = co_create_env( co_get_curr_thread_env(), attr, wrapper_func, new_arg );
+	*ppco = co;
+	return 0;
+}
+
 void    co_resume( stCoRoutine_t *co );
 void    co_yield( stCoRoutine_t *co );
 void    co_yield_ct(); //ct = current thread

--- a/example_cond.cpp
+++ b/example_cond.cpp
@@ -31,10 +31,9 @@ struct stEnv_t
 	stCoCond_t* cond;
 	queue<stTask_t*> task_queue;
 };
-void* Producer(void* args)
+void* Producer(stEnv_t* env)
 {
 	co_enable_hook_sys();
-	stEnv_t* env=  (stEnv_t*)args;
 	int id = 0;
 	while (true)
 	{
@@ -47,10 +46,9 @@ void* Producer(void* args)
 	}
 	return NULL;
 }
-void* Consumer(void* args)
+void* Consumer(stEnv_t* env)
 {
 	co_enable_hook_sys();
-	stEnv_t* env = (stEnv_t*)args;
 	while (true)
 	{
 		if (env->task_queue.empty())

--- a/example_copystack.cpp
+++ b/example_copystack.cpp
@@ -26,14 +26,13 @@
 #include "co_routine.h"
 #include "co_routine_inner.h"
 
-void* RoutineFunc(void* args)
+void* RoutineFunc(int routineid)
 {
 	co_enable_hook_sys();
-	int* routineid = (int*)args;
 	while (true)
 	{
 		char sBuff[128];
-		sprintf(sBuff, "from routineid %d stack addr %p\n", *routineid, sBuff);
+		sprintf(sBuff, "from routineid %d stack addr %p\n", routineid, sBuff);
 
 		printf("%s", sBuff);
 		poll(NULL, 0, 1000); //sleep 1s
@@ -53,7 +52,7 @@ int main()
 	for (int i = 0; i < 2; i++)
 	{
 		routineid[i] = i;
-		co_create(&co[i], &attr, RoutineFunc, routineid + i);
+		co_create(&co[i], &attr, RoutineFunc, routineid[i]);
 		co_resume(co[i]);
 	}
 	co_eventloop(co_get_epoll_ct(), NULL, NULL);

--- a/example_echocli.cpp
+++ b/example_echocli.cpp
@@ -98,12 +98,11 @@ void AddFailCnt()
 	}
 }
 
-static void *readwrite_routine( void *arg )
+static void *readwrite_routine( stEndPoint endpoint )
 {
 
 	co_enable_hook_sys();
 
-	stEndPoint *endpoint = (stEndPoint *)arg;
 	char str[8]="sarlmol";
 	char buf[ 1024 * 16 ];
 	int fd = -1;
@@ -114,7 +113,7 @@ static void *readwrite_routine( void *arg )
 		{
 			fd = socket(PF_INET, SOCK_STREAM, 0);
 			struct sockaddr_in addr;
-			SetAddr(endpoint->ip, endpoint->port, addr);
+			SetAddr(endpoint.ip, endpoint.port, addr);
 			ret = connect(fd,(struct sockaddr*)&addr,sizeof(addr));
 						
 			if ( errno == EALREADY || errno == EINPROGRESS )
@@ -206,7 +205,7 @@ int main(int argc,char *argv[])
 		for(int i=0;i<cnt;i++)
 		{
 			stCoRoutine_t *co = 0;
-			co_create( &co,NULL,readwrite_routine, &endpoint);
+			co_create( &co,NULL,readwrite_routine, endpoint);
 			co_resume( co );
 		}
 		co_eventloop( co_get_epoll_ct(),0,0 );

--- a/example_poll.cpp
+++ b/example_poll.cpp
@@ -106,11 +106,10 @@ static int CreateTcpSocket(const unsigned short shPort  = 0 ,const char *pszIP  
 	return fd;
 }
 
-static void *poll_routine( void *arg )
+static void *poll_routine( vector<task_t> v )
 {
 	co_enable_hook_sys();
 
-	vector<task_t> &v = *(vector<task_t>*)arg;
 	for(size_t i=0;i<v.size();i++)
 	{
 		int fd = CreateTcpSocket();
@@ -189,16 +188,13 @@ int main(int argc,char *argv[])
 
 //------------------------------------------------------------------------------------
 	printf("--------------------- main -------------------\n");
-	vector<task_t> v2 = v;
-	poll_routine( &v2 );
+	poll_routine( v );
 	printf("--------------------- routine -------------------\n");
 
 	for(int i=0;i<10;i++)
 	{
 		stCoRoutine_t *co = 0;
-		vector<task_t> *v2 = new vector<task_t>();
-		*v2 = v;
-		co_create( &co,NULL,poll_routine,v2 );
+		co_create( &co,NULL,poll_routine, v );
 		printf("routine i %d\n",i);
 		co_resume( co );
 	}

--- a/example_setenv.cpp
+++ b/example_setenv.cpp
@@ -62,11 +62,9 @@ void SetAndGetEnv(int iRoutineID)
 	printf("routineid %d get env CGINAME %s\n", iRoutineID, env);
 }
 
-void* RoutineFunc(void* args)
+void* RoutineFunc(stRoutineArgs_t* g)
 {
 	co_enable_hook_sys();
-
-	stRoutineArgs_t* g = (stRoutineArgs_t*)args;
 
 	SetAndGetEnv(g->iRoutineID);
 	return NULL;

--- a/example_specific.cpp
+++ b/example_specific.cpp
@@ -35,10 +35,9 @@ struct stRoutineSpecificData_t
 
 CO_ROUTINE_SPECIFIC(stRoutineSpecificData_t, __routine);
 
-void* RoutineFunc(void* args)
+void* RoutineFunc(stRoutineArgs_t* routine_args)
 {
 	co_enable_hook_sys();
-	stRoutineArgs_t* routine_args = (stRoutineArgs_t*)args;
 	__routine->idx = routine_args->routine_id;
 	while (true)
 	{
@@ -53,7 +52,7 @@ int main()
 	for (int i = 0; i < 10; i++)
 	{
 		args[i].routine_id = i;
-		co_create(&args[i].co, NULL, RoutineFunc, (void*)&args[i]);
+		co_create(&args[i].co, NULL, RoutineFunc, &args[i]);
 		co_resume(args[i].co);
 	}
 	co_eventloop(co_get_epoll_ct(), NULL, NULL);


### PR DESCRIPTION

允许 co_create 使用任意多参数的入口函数。

可以大大简化代码使用。 不需要总是对 void* 强转来强转去。十分的丑陋。